### PR TITLE
Descriptions fen

### DIFF
--- a/examples/oc_to_oscal_components.py
+++ b/examples/oc_to_oscal_components.py
@@ -28,6 +28,10 @@ def main(source):
         'NIST_SP80053r5': (
             'https://raw.githubusercontent.com/usnistgov/oscal-content/'
             'master/nist.gov/SP800-53/rev5/json/NIST_SP-800-53_rev45catalog.json'
+        ),
+        'CMS_ARS_3_1': (
+            'https://raw.githubusercontent.com/CMSgov/ars-machine-readable'
+            '/main/3.1/oscal/CMS_ARS_3_1_catalog.json'
         )
     }
 

--- a/examples/oc_to_oscal_components.py
+++ b/examples/oc_to_oscal_components.py
@@ -18,6 +18,19 @@ def main(source):
     """
     Read an OpenControl repo and emit an OSCAL component definition in JSON.
     """
+
+    # FIXME: temporarily hardwired NIST 800-53 and dictionary keys
+    source_uri_dict = {
+        'NIST_SP80053r4': (
+            'https://raw.githubusercontent.com/usnistgov/oscal-content/'
+            'master/nist.gov/SP800-53/rev4/json/NIST_SP-800-53_rev4_catalog.json'
+        ),
+        'NIST_SP80053r5': (
+            'https://raw.githubusercontent.com/usnistgov/oscal-content/'
+            'master/nist.gov/SP800-53/rev5/json/NIST_SP-800-53_rev45catalog.json'
+        )
+    }
+
     p = Path(source)
     oc = opencontrol.load(p)
 
@@ -31,27 +44,37 @@ def main(source):
         sorted_controls = sorted(o_comp.satisfies, key=lambda c: c.standard_key)
         grouped_controls = groupby(sorted_controls, lambda c: c.standard_key)
         for standard_key, o_controls in grouped_controls:
+            if standard_key in source_uri_dict:
+                source_uri = source_uri_dict[standard_key]
+            else:
+                source_uri = source_uri_dict['NIST_SP80053r4']
             ci = component.ControlImplementation(
-                description=standard_key, source=standard_key
+                description=standard_key, source=source_uri
             )
             ci.implemented_requirements = []
 
             for o_control in o_controls:
                 control_id = oscalize_control_id(o_control.control_key)
                 ir = component.ImplementedRequirement(
-                    control_id=control_id, description=f"{control_id} statements"
+                    control_id=control_id,
+                    # Default description used when narratives are all sub-parts
+                    description=(
+                        'Requirements are implemented as described '
+                        'in the included statements.'
+                    )
                 )
                 for o_statement in o_control.narrative:
-                    if o_statement.key:
+                    # Do not consider "shared" a key; may be others...
+                    if o_statement.key and o_statement.key != "shared":
                         statement_id = f"{control_id}_smt.{o_statement.key}"
-                    else:
-                        statement_id = f"{control_id}_smt"
-                    ir.add_statement(
-                        component.Statement(
-                            statement_id=statement_id,
-                            description=o_statement.text.strip(),
+                        ir.add_statement(
+                            component.Statement(
+                                statement_id=statement_id,
+                                description=o_statement.text.strip(),
+                            )
                         )
-                    )
+                    else:
+                        ir.description = o_statement.text.strip()
                 ci.implemented_requirements.append(ir)
             c.control_implementations.append(ci)
         cd.add_component(c)

--- a/examples/oc_to_oscal_components.py
+++ b/examples/oc_to_oscal_components.py
@@ -27,11 +27,15 @@ def main(source):
         ),
         'NIST_SP80053r5': (
             'https://raw.githubusercontent.com/usnistgov/oscal-content/'
-            'master/nist.gov/SP800-53/rev5/json/NIST_SP-800-53_rev45catalog.json'
+            'master/nist.gov/SP800-53/rev5/json/NIST_SP-800-53_rev5_catalog.json'
         ),
         'CMS_ARS_3_1': (
             'https://raw.githubusercontent.com/CMSgov/ars-machine-readable'
             '/main/3.1/oscal/CMS_ARS_3_1_catalog.json'
+        ),
+        'CMS_ARS_5_0': (
+            'https://raw.githubusercontent.com/CMSgov/ars-machine-readable'
+            'main/5.0/oscal/CMS_ARS_5_0_catalog.json'
         )
     }
 


### PR DESCRIPTION
This moves full-control descriptions into `implemented-requirements.description` and parts into `statements` (with a default description). See discussion at https://gitter.im/usnistgov-OSCAL/Lobby?at=6132736513ac9b6b83adb956